### PR TITLE
Fix _status property name in constructor

### DIFF
--- a/intellihide.js
+++ b/intellihide.js
@@ -78,7 +78,7 @@ var Intellihide = class HideTopBar_Intellihide {
         this._topApp = null; // The application whose window is on top on the monitor with the dock.
 
         this._isEnabled = false;
-        this.status = OverlapStatus.UNDEFINED;
+        this._status = OverlapStatus.UNDEFINED;
         this._targetBox = null;
 
         this._checkOverlapTimeoutContinue = false;


### PR DESCRIPTION
This does not really seem to affect anything, but I've noticed it while debugging other issues, might as well fix it.

It's the single place this exists as `this.status`, everywhere else there is `this._status` instead.