### PR TITLE
Better DEBUG logs in multiple classes

### DIFF
--- a/convenience.js
+++ b/convenience.js
@@ -22,6 +22,29 @@ var DEBUG = function (message) {
     if(false) global.log(Date().substr(16,8) + " [hidetopbar]: " + message);
 }
 
+var getCircularReplacer = () => {
+    const seen = new WeakSet();
+    return (_key, value) => {
+        if (typeof value === "object" && value !== null) {
+            if (seen.has(value)) {
+                return;
+            }
+                seen.add(value);
+        }
+        return value;
+    };
+}
+
+var SERIALIZE = function (value) {
+    if (value === undefined) {
+        return 'undefined';
+    } else if (value instanceof Function) {
+        return value.toString();
+    }
+
+    return JSON.stringify(value, getCircularReplacer());
+}
+
 // try to simplify global signals handling
 var GlobalSignalsHandler = class HideTopBar_GlobalSignalsHandler {
     constructor() {

--- a/desktopIconsIntegration.js
+++ b/desktopIconsIntegration.js
@@ -60,11 +60,15 @@ const Main = imports.ui.main;
 
 const ExtensionUtils = imports.misc.extensionUtils;
 const Me = ExtensionUtils.getCurrentExtension();
+const Convenience = Me.imports.convenience;
+const DEBUG = Convenience.DEBUG;
 
 const IDENTIFIER_UUID = "130cbc66-235c-4bd6-8571-98d2d8bba5e2";
 
 var DesktopIconsUsableAreaClass = class {
     constructor() {
+        DEBUG("DesktopIconsUsableAreaClass constructor()");
+
         this._extensionManager = Main.extensionManager;
         this._timedMarginsID = 0;
         this._margins = {};
@@ -96,6 +100,8 @@ var DesktopIconsUsableAreaClass = class {
      * @param {int} right Right margin in pixels
      */
     setMargins(monitor, top, bottom, left, right) {
+        DEBUG("DesktopIconsUsableAreaClass setMargins()");
+
         this._margins[monitor] = {
             'top': top,
             'bottom': bottom,
@@ -110,6 +116,8 @@ var DesktopIconsUsableAreaClass = class {
      * margins with setMargins().
      */
     resetMargins() {
+        DEBUG("DesktopIconsUsableAreaClass resetMargins()");
+
         this._margins = {};
         this._changedMargins();
     }
@@ -118,6 +126,8 @@ var DesktopIconsUsableAreaClass = class {
      * Disconnects all the signals and removes the margins.
      */
     destroy() {
+        DEBUG("DesktopIconsUsableAreaClass destroy()");
+
         if (this._emID) {
             this._extensionManager.disconnect(this._emID);
             this._emID = 0;
@@ -131,6 +141,8 @@ var DesktopIconsUsableAreaClass = class {
     }
 
     _changedMargins() {
+        DEBUG("DesktopIconsUsableAreaClass _changedMargins()");
+
         if (this._timedMarginsID) {
             GLib.source_remove(this._timedMarginsID);
         }
@@ -142,11 +154,15 @@ var DesktopIconsUsableAreaClass = class {
     }
 
     _sendMarginsToAll() {
+        DEBUG("DesktopIconsUsableAreaClass _sendMarginsToAll()");
+
         this._extensionManager.getUuids().forEach(uuid =>
             this._sendMarginsToExtension(this._extensionManager.lookup(uuid)));
     }
 
     _sendMarginsToExtension(extension) {
+        DEBUG("DesktopIconsUsableAreaClass _sendMarginsToExtension()");
+
         // check that the extension is an extension that has the logic to accept
         // working margins
         if (extension?.state !== ExtensionUtils.ExtensionState.ENABLED)

--- a/panelVisibilityManager.js
+++ b/panelVisibilityManager.js
@@ -31,6 +31,7 @@ const Convenience = Me.imports.convenience;
 const Intellihide = Me.imports.intellihide;
 const DesktopIconsIntegration = Me.imports.desktopIconsIntegration;
 const DEBUG = Convenience.DEBUG;
+const SERIALIZE = Convenience.SERIALIZE;
 
 const MessageTray = Main.messageTray;
 const PanelBox = Main.layoutManager.panelBox;
@@ -40,6 +41,7 @@ const _searchEntryBin = Main.overview._overview._controls._searchEntryBin;
 var PanelVisibilityManager = class HideTopBar_PanelVisibilityManager {
 
     constructor(settings, monitorIndex) {
+        DEBUG("PanelVisibilityManager constructor(...)");
         this._monitorIndex = monitorIndex;
         this._base_y = PanelBox.y;
         this._settings = settings;
@@ -82,7 +84,7 @@ var PanelVisibilityManager = class HideTopBar_PanelVisibilityManager {
     }
 
     hide(animationTime, trigger) {
-        DEBUG("hide(" + trigger + ")");
+        DEBUG("PanelVisibilityManager hide(" + trigger + ")");
         if(this._preventHide) return;
 
         let anchor_y = PanelBox.get_pivot_point()[1],
@@ -117,7 +119,7 @@ var PanelVisibilityManager = class HideTopBar_PanelVisibilityManager {
     }
 
     show(animationTime, trigger) {
-        DEBUG("show(" + trigger + ")");
+        DEBUG("PanelVisibilityManager show(" + trigger + ")");
         if(trigger == "mouse-enter"
            && this._settings.get_boolean('mouse-triggers-overview')) {
             Main.overview.show();
@@ -170,27 +172,36 @@ var PanelVisibilityManager = class HideTopBar_PanelVisibilityManager {
     }
 
     _isHovering(x, y) {
-        return (    y >= this._staticBox.y1 &&
-                    y < this._staticBox.y2 &&
-                    x >= this._staticBox.x1 &&
-                    x < this._staticBox.x2 );
+        DEBUG("PanelVisibilityManager _isHovering(" + x + ", " + y + ")");
+        const result = (y >= this._staticBox.y1 &&
+                        y < this._staticBox.y2 &&
+                        x >= this._staticBox.x1 &&
+                        x < this._staticBox.x2);
+        DEBUG("PanelVisibilityManager _isHovering => " + result);
+        return result;
     }
 
     _handlePointer(x, y) {
+        DEBUG("PanelVisibilityManager _handlePointer(" + x + ", " + y + ")");
         if(!this._animationActive && !this._isHovering(x, y)) {
+            DEBUG("PanelVisibilityManager _handlePointer(" + x + ", " + y + "): if");
             this._handleMenus();
         }
     }
 
     _handleMenus() {
+        DEBUG("PanelVisibilityManager _handleMenus()");
         if(!Main.overview.visible) {
+            DEBUG("PanelVisibilityManager _handleMenus(): overview not visible");
             let blocker = Main.panel.menuManager.activeMenu;
             if(blocker == null) {
+                DEBUG("PanelVisibilityManager _handleMenus(): blocker == null");
                 this.hide(
                     this._settings.get_double('animation-time-autohide'),
                     "mouse-left"
                 );
             } else {
+                DEBUG("PanelVisibilityManager _handleMenus(): blocker not null");
                 this._blockerMenu = blocker;
                 this._menuEvent = this._blockerMenu.connect(
                     'open-state-changed',
@@ -208,6 +219,7 @@ var PanelVisibilityManager = class HideTopBar_PanelVisibilityManager {
     }
 
     _handleShortcut() {
+        DEBUG("PanelVisibilityManager _handleShortcut()");
         var delay_time = this._settings.get_double('shortcut-delay');
         if(this._shortcutTimeout) {
             if(this._shortcutTimeout !== true) {
@@ -264,6 +276,7 @@ var PanelVisibilityManager = class HideTopBar_PanelVisibilityManager {
     }
 
     _disablePressureBarrier() {
+        DEBUG("PanelVisibilityManager _disablePressureBarrier()");
         if(this._pointerListener) {
             this._pointerWatcher._removeWatch(this._pointerListener);
             this._pointerListener = null;
@@ -276,6 +289,7 @@ var PanelVisibilityManager = class HideTopBar_PanelVisibilityManager {
     }
 
     _initPressureBarrier() {
+        DEBUG("PanelVisibilityManager _initPressureBarrier()");
         this._panelPressure = new Layout.PressureBarrier(
             this._settings.get_int('pressure-threshold'),
             this._settings.get_int('pressure-timeout'),
@@ -312,7 +326,7 @@ var PanelVisibilityManager = class HideTopBar_PanelVisibilityManager {
     }
 
     _updateStaticBox() {
-        DEBUG("_updateStaticBox()");
+        DEBUG("PanelVisibilityManager _updateStaticBox()");
         let anchor_y = PanelBox.get_pivot_point()[1];
         this._staticBox.init_rect(
             PanelBox.x, PanelBox.y-anchor_y, PanelBox.width, PanelBox.height
@@ -323,6 +337,7 @@ var PanelVisibilityManager = class HideTopBar_PanelVisibilityManager {
     }
 
     _updateHotCorner(panel_hidden) {
+        DEBUG("PanelVisibilityManager _updateHotCorner(" + panel_hidden + ")");
         let HotCorner = null;
         for(var i = 0; i < Main.layoutManager.hotCorners.length; i++){
           let hc = Main.layoutManager.hotCorners[i];
@@ -343,22 +358,26 @@ var PanelVisibilityManager = class HideTopBar_PanelVisibilityManager {
     }
 
     _updateSettingsHotCorner() {
+        DEBUG("PanelVisibilityManager _updateSettingsHotCorner()");
         this.hide(0.1, "hot-corner-setting-changed");
     }
 
     _updateSettingsMouseSensitive() {
+        DEBUG("PanelVisibilityManager _updateSettingsMouseSensitive()");
         if(this._settings.get_boolean('mouse-sensitive')) {
             this._disablePressureBarrier();
             this._initPressureBarrier();
         } else this._disablePressureBarrier();
     }
-    
+
     _updateSettingsShowInOverview() {
+        DEBUG("PanelVisibilityManager _updateSettingsShowInOverview()");
         this._showInOverview = this._settings.get_boolean('show-in-overview');
         this._updateSearchEntryMargin();
     }
 
     _updateSearchEntryMargin() {
+        DEBUG("PanelVisibilityManager _updateSearchEntryMargin()");
         if (!_searchEntryBin) return;
         const scale = Main.layoutManager.primaryMonitor.geometry_scale;
         const margin = PanelBox.height / scale;
@@ -366,6 +385,7 @@ var PanelVisibilityManager = class HideTopBar_PanelVisibilityManager {
     }
 
     _updateIntellihideStatus() {
+        DEBUG("PanelVisibilityManager _updateIntellihideStatus()");
         if(this._settings.get_boolean('enable-intellihide')) {
             this._intellihideBlock = false;
             this._preventHide = false;
@@ -379,6 +399,7 @@ var PanelVisibilityManager = class HideTopBar_PanelVisibilityManager {
     }
 
     _updatePreventHide() {
+        DEBUG("PanelVisibilityManager _updatePreventHide()");
         if(this._intellihideBlock) return;
 
         this._preventHide = !this._intellihide.getOverlapStatus();
@@ -391,6 +412,7 @@ var PanelVisibilityManager = class HideTopBar_PanelVisibilityManager {
     }
 
     _bindUIChanges() {
+        DEBUG("PanelVisibilityManager _bindUIChanges()");
         this._signalsHandler = new Convenience.GlobalSignalsHandler();
         this._signalsHandler.add(
             [
@@ -470,6 +492,7 @@ var PanelVisibilityManager = class HideTopBar_PanelVisibilityManager {
     }
 
     _bindSettingsChanges() {
+        DEBUG("PanelVisibilityManager _bindSettingsChanges()");
         this._signalsHandler = new Convenience.GlobalSignalsHandler();
         this._signalsHandler.addWithLabel("settings",
             [
@@ -511,6 +534,7 @@ var PanelVisibilityManager = class HideTopBar_PanelVisibilityManager {
     }
 
     destroy() {
+        DEBUG("PanelVisibilityManager destroy()");
         if (this._bindTimeoutId) {
             GLib.source_remove(this._bindTimeoutId);
             this._bindTimeoutId = 0;


### PR DESCRIPTION
> NOTE: to enable debugging, change the `if` clause inside the DEBUG helepr to `true`.

Multiple DEBUG statements were added to make journalctl logs more useful in debugging issues.

The SERIALIZE helper was included to properly print out function arguments.

Two new methods `_checkOverlapSignal` and `_windowCreatedSignal` added to the `Intellihide` class to allow trackng which signal triggers a particular change to occur.