### PR TITLE
Fix intellihide for Desktop Icons NG and Gtk4-Ding

### DIFF
--- a/intellihide.js
+++ b/intellihide.js
@@ -329,6 +329,11 @@ var Intellihide = class HideTopBar_Intellihide {
         if (!metaWindow)
             return false;
 
+        const ignoreApps = [ "com.rastersoft.ding", "com.desktop.ding" ];
+        const wmApp = metaWindow.get_gtk_application_id();
+        if (ignoreApps.includes(wmApp) && metaWindow.is_skip_taskbar())
+            return false;
+
         // The DropDownTerminal extension uses the POPUP_MENU window type hint
         // so we match its window by wm class instead
         if (metaWindow.get_wm_class() == 'DropDownTerminalWindow')


### PR DESCRIPTION
This extension currently does not detect the window for Gtk4-DING desktop extensions as the desktop window for icons. Therefore when the desktop is in focus, the top bar hides, and this is not desirable.

This patch detects the DING window for both Gtk3 DING and the Gtk4 branch. It therefore does not hide with the default desktop window showing the icons.