### PR TITLE
Update minimized searchbar offset

### DIFF
--- a/panelVisibilityManager.js
+++ b/panelVisibilityManager.js
@@ -361,7 +361,7 @@ var PanelVisibilityManager = class HideTopBar_PanelVisibilityManager {
     _updateSearchEntryPadding() {
         if (!_searchEntryBin) return;
         const scale = Main.layoutManager.primaryMonitor.geometry_scale;
-        const offset = PanelBox.height / scale; 
+        const offset = this._showInOverview ? PanelBox.height / scale : 0; 
         _searchEntryBin.set_style(this._showInOverview ? `padding-top: ${offset}px;` : null);
     }
 


### PR DESCRIPTION
When the search bar is not visible, the offset is still calculated and the container eats inputs meant for underlying windows.  This change addresses this by setting the offset to 0 when the searchbar is not visible, allowing underlying windows to be clicked where the searchbar would be shown when maximized.